### PR TITLE
Enable easier import

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ As a library
 
 pip install bootstrap_2to3
 
-    from bootstrap_2to3.bootstrap_2to3 import convert
-    
+    from bootstrap_2to3 import convert
+
     convert()  # To convert all .html files under current directory
     convert('/user/works/project')  # To convert all .html files under given directory
-
-
-

--- a/bootstrap_2to3/__init__.py
+++ b/bootstrap_2to3/__init__.py
@@ -1,0 +1,1 @@
+from bootstrap_2to3.bootstrap_2to3 import convert


### PR DESCRIPTION
This update makes the convert function a bit easier to import, like:

```
from bootstrap_2to3 import convert
```

I also updated the README to reflect that
