### PR TITLE
Support Python 3

### DIFF
--- a/bootstrap_2to3/bootstrap_2to3.py
+++ b/bootstrap_2to3/bootstrap_2to3.py
@@ -39,7 +39,7 @@ class TwoToThree(object):
         return self.html
 
     def replace_simple_classes(self):
-        for key, val in class_mapping.iteritems():
+        for key, val in class_mapping.items():
             self.html = self.html.replace(key, val)
 
     def replace_span_classes(self):

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,8 @@ setup(
     license='BSD licence',
     description='Script to migrate bootstrap 2 templates to bootstrap3.',
     #long_description=open('README.md').read(),
+    classifiers=(
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3'
+    )
 )


### PR DESCRIPTION
This PR adds support for Python 3, and adds Python 3 to the trove classifiers. It was a tiny change, just changing `iteritems` to `items`
