### PR TITLE
Add console script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Helps to convert your templates from bootstap2 to 3.
 How to use as a script
 ----------------------
 
-python bootstrap_2to3.py <root-project-directory>
+Install from pip and use the console script:
+
+    pip install bootstrap_2to3
+    bootstrap_2to3 <root-project-directory>
+
+Or, if you are running from source:
+
+    python bootstrap_2to3.py <root-project-directory>
 
 This finds all .html files under the root folder and replaces bootstrap2 classes.
 
@@ -23,9 +30,6 @@ As a library
 pip install bootstrap_2to3
 
     from bootstrap_2to3.bootstrap_2to3 import convert
-    
+
     convert()  # To convert all .html files under current directory
     convert('/user/works/project')  # To convert all .html files under given directory
-
-
-

--- a/bootstrap_2to3/bootstrap_2to3.py
+++ b/bootstrap_2to3/bootstrap_2to3.py
@@ -67,10 +67,14 @@ def convert(root_folder):
             fw.write(output)
 
 
-if __name__ == "__main__":
+def main():
     try:
         root_folder = sys.argv[1]
     except IndexError:
         root_folder = os.getcwd()
     #FIXME: copy to a new directory before manipulating files
     convert(root_folder)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='bootstrap_2to3',
     version='0.1.1',
     author='Jayesh',
     author_email='jayesh@jayeshv.info',
+    entry_points={
+        'console_scripts': ['bootstrap_2to3=bootstrap_2to3.bootstrap_2to3:main'],
+    },
     packages=['bootstrap_2to3'],
     url='https://github.com/jayeshv/bootstrap_2to3',
     license='BSD licence',


### PR DESCRIPTION
This update makes a `bootstrap_2to3` command line script that works the same way as:

```
python bootstrap_2to3.py
```

I changed the README to demonstrate both options.
